### PR TITLE
🔒 Fixes for multiple JavaScript vulnerabilities

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -76,6 +76,7 @@ end)
 -- Callbacks
 
 RegisterNUICallback("NUIFocusOff", function(data, cb)
+    TriggerServerEvent('qb-atms:server:unathorize')
     SetNuiFocus(false, false)
     SendNUIMessage({
         status = "closeATM"
@@ -128,5 +129,13 @@ RegisterNUICallback("removeCard", function(data, cb)
         else
             QBCore.Functions.Notify('Failed to delete card.', 'error')
         end
+    end, data)
+end)
+
+RegisterNUICallback('verifyPIN', function(data, cb)
+    QBCore.Functions.TriggerCallback('qb-atms:server:verifyPIN', function(isVerified)
+        SendNUIMessage({
+            status = isVerified and 'pinSuccess' or 'pinFailed'
+        })
     end, data)
 end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -76,7 +76,7 @@ end)
 -- Callbacks
 
 RegisterNUICallback("NUIFocusOff", function(data, cb)
-    TriggerServerEvent('qb-atms:server:unathorize')
+    TriggerServerEvent('qb-atms:server:unauthorize')
     SetNuiFocus(false, false)
     SendNUIMessage({
         status = "closeATM"

--- a/server/main.lua
+++ b/server/main.lua
@@ -128,7 +128,7 @@ RegisterNetEvent('qb-atms:server:doAccountWithdraw', function(data)
     end
 end)
 
-RegisterNetEvent('qb-atms:server:unathorize', function() authorized[source] = nil end)
+RegisterNetEvent('qb-atms:server:unauthorize', function() authorized[source] = nil end)
 
 -- Callbacks
 


### PR DESCRIPTION
**Describe Pull request**
This pull request fixes multiple issues found inside `qb-atms.js` (hereafter referred to as "script"). These issues/vulnerabilities can be exploited through FiveM Developer Tools (Chrome Inspector) by directly modifying the JavaScript files.


## Multiple PIN bypass methods
### JavaScript Comparison Bypass
The first vulnerability is caused by the comparison of PIN number inside the script. Since all the JavaScript files are loaded client-side, we should avoid doing any important checks or comparisons in them without double checking it with server. Since we currently do PIN authentication purely inside the script, we can easily modify the line below to **ALWAYS** give us access into any card we use.

```js
if (currentVal == clientPin)  // Current comparison (vulnerable)

if (true)  // Exploited line (always grants access)
if (clientPin == clientPin)  // Exploited line (always grants access)
```

To fix this issue, I removed all the comparisons and authentication attempts inside the script and moved them to server-side callback named `qb-atms:server:verifyPIN` that can be found at the bottom of `server/main.lua`

### Custom post request to NUI Callback
After (or even before) fixing the issue above, we are left with another vulnerability. Since the NUI callback named `loadBankingAccount` inside `client/main.lua` doesn't verify whether the user is authorized to use the card, we can craft a custom post request that will grant us access to **ANY** credit card that is registered in the server. All we need is Citizen ID of the owner and the Card Number.

After we get that, we can craft a request like this and gain immediate access to the card
```js
$.post("https://qb-atms/loadBankingAccount", JSON.stringify({
    cid: "DKH47814",
    cardnumber: "6122691686594159"
}));
```

To fix this issue, the `server/main.lua` now has a table called `authorized` that stores which players are authorized to use certain cards. If the user is not in there and tries to load the card anyway (custom post request) it now doesn't let them through. This is all thanks to this line.

```lua
if not authorized[source] or authorized[source] ~= data.cardnumber then return end
```

<br>

## Infinite money
There is another method that could potentially allow two users to get unlimited money on their bank account.

Due to severity of this issue, I will not disclose any further information on how it works in order to prevent exploitation of this vulnerability, but I would be happy to share it either in private chat (with staff only of course) or once this request is merged (since it fixes this issue) 

<br>

---

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**