### PR TITLE
Add ATMModel objects as Literals

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -3,8 +3,8 @@ Config = {}
 Config.DailyLimit = 5000
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true'
 Config.ATMModels = {
-    "prop_atm_01",
-    "prop_atm_02",
-    "prop_atm_03",
-    "prop_fleeca_atm"
+    `prop_atm_01`,
+    `prop_atm_02`,
+    `prop_atm_03`,
+    `prop_fleeca_atm`
 }


### PR DESCRIPTION
**Describe Pull request**
The ATMs do not work using the current version of qb-target. Converting the list of ATMs to literals made it work.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
