### PR TITLE
Add client side validation + error message to atm

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-ATM'
-version '1.2.0'
+version '1.2.1'
 
 shared_script 'config.lua'
 

--- a/nui/index.html
+++ b/nui/index.html
@@ -166,8 +166,12 @@
                                             <div class="card-body">
                                                 <div class="container-fluid">
                                                     <div class="row m-1">
-                                                        <div class="col-6"><button class="btn btn-secondary2 btn-block" data-action="ATMwithdraw" data-amount="100">Withdrawal $100</button></div>
-                                                        <div class="col-6"><button class="btn btn-secondary2 btn-block" data-action="ATMwithdraw" data-amount="1000">Withdrawal $1000</button></div>
+                                                        <div class="col-6">
+                                                            <button class="btn btn-secondary2 btn-block" data-withdrawal="preset" data-amount="100">Withdrawal $100</button>
+                                                        </div>
+                                                        <div class="col-6">
+                                                            <button class="btn btn-secondary2 btn-block" data-withdrawal="preset" data-amount="1000">Withdrawal $1000</button>
+                                                        </div>
                                                     </div>
                                                 </div>
                                             </div>
@@ -213,18 +217,16 @@
                                                 <div class="card mb-3" style="background:rgba(51, 51, 51, 0.8); color: white">
                                                         <div class="card-body">
                                                             <div class="container-fluid">
-                                                                <div class="row" id="withdrawATMError" style="display:none;">
-                                                                    <div class="col-12">
-                                                                        <div class="alert alert-danger" role="alert" id="withdrawATMErrorMsg">
-                                                                            
-                                                                        </div>
+                                                                <div class="row">
+                                                                    <div class="alert alert-danger d-none" id="withdrawATMErrorMsg">
+                                                                        An unexpected error has occured, please try again later.
                                                                     </div>
                                                                 </div>
-                                                                    <div class="row">
-                                                                        <div class="col-12 content">Please specify the amount you wish to Withdraw below.</div>
-                                                                    </div>
+                                                                <div class="row">
+                                                                    <div class="col-12 content">Please specify the amount you wish to Withdraw below.</div>
+                                                                </div>
                                                                 <div class="row mt-2">
-                                                                    <div class="col-3 my-auto"><label for="withdrawAmounATMt"><small>Amount to Withdraw</small></label></div>
+                                                                    <div class="col-3 my-auto"><label for="withdrawAmountATM"><small>Amount to Withdraw</small></label></div>
                                                                     <div class="col-9"><input type="number" placeholder="$" class="form-control" id="withdrawAmountATM" name="withdrawAmountATM"></div>
                                                                 </div>
                                                             </div>
@@ -234,7 +236,9 @@
                                         </div>
                                     </div>
                                     <div class="row" style="position: relative; top: 15px;">
-                                        <div class="col-12 text-center"><button class="btn btn-secondary2" id="initiateWithdrawATM">Complete Withdrawal</button></div>
+                                        <div class="col-12 text-center">
+                                            <button class="btn btn-secondary2" data-withdrawal="manual">Complete Withdrawal</button>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/nui/qb-atms.js
+++ b/nui/qb-atms.js
@@ -179,26 +179,27 @@ $( function() {
         }));
     });
 
-    $(document).on('click','[data-action=ATMwithdraw]',function(){
-        var amount = $(this).data('amount');
-        if(amount !== undefined && amount !== null && amount !== 0) {
-            $.post("https://qb-atms/doATMWithdraw", JSON.stringify({
-                amount: parseInt(amount),
-                cid: clientCid,
-                cardnumber: cardNumb
-            }));
-        }
+    document.querySelector('#withdrawAmountATM').addEventListener('keyup', (evt) => {
+        document.querySelector('[data-withdrawal=manual]').setAttribute('data-amount', evt.target.value);
     });
 
-    $(document).on('click','#initiateWithdrawATM',function(){
-        var amount = $('#withdrawAmountATM').val();
-        if(amount !== undefined && amount !== null && amount !== 0) {
+    document.querySelectorAll('[data-withdrawal]').forEach(function (element) {
+        element.addEventListener('click', (evt) => {
+            const amount = evt.target.getAttribute('data-amount');
+            const errorMessage = document.getElementById('withdrawATMErrorMsg');
+            errorMessage.classList.add('d-none');
+
+            if (amount == undefined || amount == null || amount <= 0) {
+                errorMessage.classList.remove('d-none');
+                return errorMessage.innerHTML = 'An error occurred with your withdrawal, please try again.';
+            }
+
             $.post("https://qb-atms/doATMWithdraw", JSON.stringify({
                 amount: parseInt(amount),
                 cid: clientCid,
                 cardnumber: cardNumb
             }));
-        }
+        });
     });
 
     $(document).on('click','[data-act=enterNumber]',function(){


### PR DESCRIPTION
**Describe Pull request**
Lack of client side validation means the atm is able to submit negative integers to the backend.
This change prevents that.

I've also merged 2 functions into one and rewritten it using vanilla JS.

+ An error message when the validation fails

Fixes:
https://github.com/qbcore-framework/qb-atms/issues/52
https://github.com/qbcore-framework/qb-atms/issues/48
