### PR TITLE
Check for a locked card

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -229,7 +229,7 @@ QBCore.Functions.CreateCallback('qb-atms:server:loadBankAccount', function(sourc
             return
         end
 
-        -- Visa card removal
+        -- Master card removal
         local foundMC = xPlayer.Functions.GetCardSlot( cardnumber, "mastercard" )
         if foundMC then
             exports["qb-inventory"]:RemoveItem(src, "mastercard", 1, foundMC)


### PR DESCRIPTION
This piece of code checks if the used card is locked after the pin code has been entered. If the card is locked it will be removed and the player that used the card will be given a notification that the card can't be used and has been removed.

I added this code because the check on a locked card didn't exist yet whilst this was a feature of the master and visa cards in the banking script.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
I have personally checked if the code works and it does. I checked it with my own player but also gave the card to another player (and locked it). In both cases when the card was locked the used card got removed.

- Does your code fit the style guidelines? [yes/no]
I think it does.

- Does your PR fit the contribution guidelines? [yes/no]
Yes.
